### PR TITLE
Close smarts file handle after reading

### DIFF
--- a/dimorphite_dl.py
+++ b/dimorphite_dl.py
@@ -713,11 +713,8 @@ class ProtSubstructFuncs:
 
         pwd = os.path.dirname(os.path.realpath(__file__))
         site_structures_file = "{}/{}".format(pwd, "site_substructures.smarts")
-        lines = [
-            l
-            for l in open(site_structures_file, "r")
-            if l.strip() != "" and not l.startswith("#")
-        ]
+        with open(site_structures_file, "r") as f:
+            lines = [l for l in f if l.strip() != "" and not l.startswith("#")]
 
         return lines
 


### PR DESCRIPTION
This PR fixes the following warning:
```
dimorphite_dl/dimorphite_dl.py:718: ResourceWarning: unclosed file <_io.TextIOWrapper name='dimorphite_dl/site_substructures.smarts' mode='r' encoding='UTF-8'>
  for l in open(site_structures_file, "r")
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```